### PR TITLE
Unspecified execution order. Broken in Haxe 3.3.

### DIFF
--- a/ogg/Ogg.hx
+++ b/ogg/Ogg.hx
@@ -147,7 +147,8 @@ private class Ogg_helper {
             );
         }
 
-        callbacks.set(cb_seq, { userdata:userdata, file:file, callbacks:_callbacks, id:++cb_seq });
+		var _id = ++cb_seq;
+        callbacks.set(_id, { userdata:userdata, file:file, callbacks:_callbacks, id: _id });
 
         return @:privateAccess Ogg.internal_open_callbacks(cb_seq, file, initial, ibytes);
 


### PR DESCRIPTION
Execution order for increment operator is different in haxe 3.3 and might change again in the future. This leads to a failure during .ogg file reading. This pull request makes sure execution order is correct and identifier is the same as map key.
