### PR TITLE
Workaround for https://github.com/HaxeFoundation/hxcpp/issues/462

### DIFF
--- a/ogg/Ogg.hx
+++ b/ogg/Ogg.hx
@@ -210,12 +210,22 @@ private class Ogg_helper {
 
 } //Ogg_helper
 
+#if (haxe_ver >= 3.3)
+@:structInit
+private class InternalCallbackInfo {
+    public var id:Int;
+    public var userdata:Dynamic;
+    public var file:OggVorbisFile;
+    public var callbacks:OggCallbacks;
+}
+#else
 private typedef InternalCallbackInfo = {
     var id:Int;
     var userdata:Dynamic;
     var file:OggVorbisFile;
     var callbacks:OggCallbacks;
 }
+#end
 
 //userdata,size,nmemb,data
 typedef OggReadFN = Dynamic->Int->Int->BytesData->Int;


### PR DESCRIPTION
Structures handling with native pointers is broken in haxe 3.3.
Using new haxe feature @:structInit as a workaround.

It's a temporary solution. If https://github.com/HaxeFoundation/hxcpp/issues/462 gets released this PR can be dropped.
